### PR TITLE
Add more APIs to match python: LineNo(), FileLineNo() and IsFirstLine()

### DIFF
--- a/fileinput.go
+++ b/fileinput.go
@@ -59,13 +59,14 @@ type (
 		Open      func(name string) (io.ReadCloser, error) // Function to open files.
 		SplitFunc bufio.SplitFunc                          // Argument of Split() of bufio.Split.
 
-		sc       *bufio.Scanner
-		rc       io.ReadCloser
-		icurr    int
-		err      error
-		filename string
-		lineNo   int
-		closed   bool
+		sc         *bufio.Scanner
+		rc         io.ReadCloser
+		icurr      int
+		err        error
+		filename   string
+		lineNo     int
+		fileLineNo int
+		closed     bool
 	}
 )
 
@@ -90,12 +91,14 @@ func (s *Scanner) Scan() bool {
 				s.sc.Split(s.SplitFunc)
 			}
 			s.filename = s.Args[s.icurr]
+			s.fileLineNo = 0
 		}
 
 		r := s.sc.Scan()
 		s.err = s.sc.Err()
 		if r {
 			s.lineNo++
+			s.fileLineNo++
 			return true
 		}
 		s.Next()
@@ -142,6 +145,16 @@ func (s *Scanner) Filename() string {
 // LineNo returns the cumulative line number of the line just read.
 func (s *Scanner) LineNo() int {
 	return s.lineNo
+}
+
+// FileLineNo returns the line number in the file of the line just read.
+func (s *Scanner) FileLineNo() int {
+	return s.fileLineNo
+}
+
+// IsFirstLine returns the line number in the file of the line just read.
+func (s *Scanner) IsFirstLine() bool {
+	return s.fileLineNo == 1
 }
 
 // Close closes the Scanner.

--- a/fileinput.go
+++ b/fileinput.go
@@ -64,6 +64,7 @@ type (
 		icurr    int
 		err      error
 		filename string
+		lineNo   int
 		closed   bool
 	}
 )
@@ -94,6 +95,7 @@ func (s *Scanner) Scan() bool {
 		r := s.sc.Scan()
 		s.err = s.sc.Err()
 		if r {
+			s.lineNo++
 			return true
 		}
 		s.Next()
@@ -135,6 +137,11 @@ func (s *Scanner) Err() error {
 // Before the first line has been read, returns empty string.
 func (s *Scanner) Filename() string {
 	return s.filename
+}
+
+// LineNo returns the cumulative line number of the line just read.
+func (s *Scanner) LineNo() int {
+	return s.lineNo
 }
 
 // Close closes the Scanner.

--- a/fileinput_test.go
+++ b/fileinput_test.go
@@ -33,12 +33,20 @@ func TestLines(t *testing.T) {
 		switch line {
 		case "a01":
 			assert.Equal(1, sc.LineNo())
+			assert.Equal(1, sc.FileLineNo())
+			assert.Equal(true, sc.IsFirstLine())
 		case "a03":
 			assert.Equal(3, sc.LineNo())
+			assert.Equal(3, sc.FileLineNo())
+			assert.Equal(false, sc.IsFirstLine())
 		case "c01":
 			assert.Equal(7, sc.LineNo())
+			assert.Equal(1, sc.FileLineNo())
+			assert.Equal(true, sc.IsFirstLine())
 		case "c02":
 			assert.Equal(8, sc.LineNo())
+			assert.Equal(2, sc.FileLineNo())
+			assert.Equal(false, sc.IsFirstLine())
 		}
 	}
 	assert.NoError(sc.Err())

--- a/fileinput_test.go
+++ b/fileinput_test.go
@@ -26,7 +26,20 @@ func TestLines(t *testing.T) {
 	}
 	lines := []string{}
 	for sc.Scan() {
-		lines = append(lines, sc.Text())
+		line := sc.Text()
+		lines = append(lines, line)
+
+		// spot check progress fields
+		switch line {
+		case "a01":
+			assert.Equal(1, sc.LineNo())
+		case "a03":
+			assert.Equal(3, sc.LineNo())
+		case "c01":
+			assert.Equal(7, sc.LineNo())
+		case "c02":
+			assert.Equal(8, sc.LineNo())
+		}
 	}
 	assert.NoError(sc.Err())
 	expected := []string{
@@ -35,4 +48,5 @@ func TestLines(t *testing.T) {
 		"c01", "c02", "c03",
 	}
 	assert.Equal(expected, lines)
+	assert.Equal(len(expected), sc.LineNo())
 }


### PR DESCRIPTION
Add APIs to match the python fileinput - https://docs.python.org/3.0/library/fileinput.html
- LineNo() - the cumulative total line number
- FileLineNo() - the line number in the current file
- IsFirstLine() - indicates if we're the first line in the file.

PS: Thanks for the library - was just what I was looking for.  I just needed a few more API to simplify porting an existing python tool.

